### PR TITLE
Result#showページで承認ステータス変更時のバグを修正

### DIFF
--- a/app/views/approvals/create.turbo_stream.haml
+++ b/app/views/approvals/create.turbo_stream.haml
@@ -7,6 +7,6 @@
   = render partial: 'results/approval', locals: { approval: @approval }
 = turbo_stream.remove 'no_approval_text'
 = turbo_stream.replace 'result_status' do
-  = render partial: 'results/status', locals: { result: @result }
+  = render partial: 'results/status_wrapper', locals: { result: @result }
 
 = turbo_stream_flash

--- a/app/views/results/_status_wrapper.html.haml
+++ b/app/views/results/_status_wrapper.html.haml
@@ -1,2 +1,2 @@
 %div.result_status-wrapper#result_status
-  = render 'status', result: result
+  = render 'results/status', result: result

--- a/app/views/results/show.html.haml
+++ b/app/views/results/show.html.haml
@@ -36,6 +36,9 @@
       - unless @result.approvals.any?
         %p#no_approval_text 承認履歴はまだありません
 
+  %div.actions
+    = link_to "検査結果一覧", plant_sample_path(@result.sample.plant, @result.sample), class: "btn btn-show"
+
   .div-comment
     %p 直近20検体の結果について、平均・最大・最小値を表示します。
     %p グラフで表示します。


### PR DESCRIPTION
- approval/create.turbo_streamでreplaceするファイルをstatusからstatus_wrapperに修正
- Result#showページの下部にSample#showへ戻るボタンを追加