### PR TITLE
承認済みの結果を編集できないようにする

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -89,3 +89,7 @@ body {
   border: 1px dashed #333;
   padding: 8px 16px;
 }
+
+.inactive {
+  opacity: 0.2;
+}

--- a/app/assets/stylesheets/sample.scss
+++ b/app/assets/stylesheets/sample.scss
@@ -143,17 +143,36 @@
   display: block;
   width: 32px;
   padding-top: 2px;
+  transition: opacity 0.3s ease;
+
+  &:hover {
+    opacity: 0.7;
+  }
 }
 
 .sample-edit {
   display: block;
   width: 32px;
+  
+}
+
+a.sample-edit{
+  transition: opacity 0.3s ease;
+
+  &:hover {
+    opacity: 0.7;
+  }
 }
 
 .sample-delete {
   display: block;
   width: 22px;
   padding-top: 4px;
+  transition: opacity 0.3s ease;
+
+  &:hover {
+    opacity: 0.7;
+  }
 }
 
 

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -2,9 +2,10 @@ class ResultsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_sample, only: [ :new, :create, :edit, :update, :destroy ]
   before_action :set_test_items, only: [ :new, :create, :edit, :update, :destroy ]
+  before_action :set_result, only: [ :show, :destroy ]
+  before_action :result_approved?, only: [ :edit, :update ]
 
   def show
-    @result = Result.find(params[:id])
     @recent_results = Result.joins(:sample).where(test_item_id: @result.test_item_id, sample: { plant_id: @result.sample.plant_id }).order(sampling_date: :desc).limit(20)
     label = @recent_results.pluck('sample.sampling_date').reverse
     data = @recent_results.pluck(:value).reverse
@@ -42,11 +43,11 @@ class ResultsController < ApplicationController
   end
 
   def edit
-    @result = Result.find(params[:id])
+    # @result = Result.find(params[:id])
   end
 
   def update
-    @result = Result.find(params[:id])
+    # @result = Result.find(params[:id])
     if @result.update(result_params)
       flash.now.notice = '変更しました'
     else
@@ -56,7 +57,6 @@ class ResultsController < ApplicationController
   end
 
   def destroy
-    @result = Result.find(params[:id])
     @result.destroy!
     flash.now.notice = '削除しました'
   end
@@ -72,5 +72,16 @@ class ResultsController < ApplicationController
 
   def set_test_items
     @test_items = TestItem.all.order(:sort_order)
+  end
+
+  def set_result
+    @result = Result.find(params[:id])
+  end
+
+  def result_approved?
+    set_result
+    if @result.approved?
+      redirect_to plant_sample_path(params[:plant_id], params[:sample_id]),  notice: '承認済みの結果は編集できません'
+    end
   end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -20,6 +20,7 @@ class Result < ApplicationRecord
   has_many :approvals, dependent: :destroy
 
   validates :value, numericality: { allow_nil: true }
+  validate :check_editable
 
   def latest_approval
     approvals.order(created_at: :desc).first
@@ -28,4 +29,11 @@ class Result < ApplicationRecord
   def approved?
     latest_approval&.approved?
   end
+
+  private
+    def check_editable
+      if approved?
+        errors.add(:base, '承認済みの結果は編集できません')
+      end
+    end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -20,4 +20,12 @@ class Result < ApplicationRecord
   has_many :approvals, dependent: :destroy
 
   validates :value, numericality: { allow_nil: true }
+
+  def latest_approval
+    approvals.order(created_at: :desc).first
+  end
+
+  def approved?
+    latest_approval&.approved?
+  end
 end

--- a/app/views/samples/_result.html.haml
+++ b/app/views/samples/_result.html.haml
@@ -9,7 +9,11 @@
     .sample-result_buttons
       = link_to plant_sample_result_path(result.sample.plant, result.sample, result), class: "sample-chart", data: { turbo: false } do
         = image_tag 'chart.svg'
-      = link_to edit_plant_sample_result_path(result.sample.plant, result.sample, result), class: "sample-edit", data: { turbo_frame: 'modal' } do
-        = image_tag 'edit.svg'
+      - unless result.approved?
+        = link_to edit_plant_sample_result_path(result.sample.plant, result.sample, result), class: "sample-edit", data: { turbo_frame: 'modal' } do
+          = image_tag 'edit.svg'
+      - else
+        .sample-edit.inactive
+          = image_tag 'edit.svg'
       = link_to plant_sample_result_path(result.sample.plant, result.sample, result), data: {turbo_method: :delete, turbo_confirm: "この検査結果を削除しますか？" }, class: "sample-delete" do
         = image_tag 'delete.svg'


### PR DESCRIPTION
- resultモデルにバリデーションを設定
- コントローラーでeditのbefore_actionで承認済みのときはリダイレクトに
- viewで承認済みのeditボタンを無効に