### PR TITLE
Approvalにバリデーションを設定

### DIFF
--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -1,6 +1,7 @@
 class ApprovalsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_result, only: [ :new, :create ]
+  before_action :result_approved?, only: [ :new, :create ]
 
   def index
     # 各result_idの最新のapprovalを取得
@@ -50,5 +51,12 @@ class ApprovalsController < ApplicationController
 
   def set_result
     @result = Result.find(params[:result_id])
+  end
+
+  def result_approved?
+    set_result
+    if @result.approved?
+      redirect_to plant_sample_path(params[:plant_id], params[:sample_id]),  notice: '承認済みです'
+    end
   end
 end

--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -23,26 +23,31 @@ class ApprovalsController < ApplicationController
 
   def create
     @approval = @result.approvals.build(approval_params)
+    @approval.action = params[:submit_type]
 
-    case params[:submit_type]
-    when 'requested'
-      @approval.action = 'requested'
-      message_notice = '承認依頼しました'
-      message_error = '承認依頼できませんでした'
-    when 'approved'
-      @approval.action = 'approved'
-      message_notice = '承認しました'
-      message_error = '承認できませんでした'
-    when 'rejected'
-      @approval.action = 'rejected'
-      message_notice = '差戻しました'
-      message_error = '差戻しできませんでした'
-    end
-
-    if @approval.save
-      flash.now.notice = message_notice
+    if @approval.requested?
+      if @approval.save
+        flash.now.notice = '承認依頼しました'
+      else
+        flash.now[:error] = '承認依頼できませんでした'
+        render :new, status: :unprocessable_entity
+      end
+    elsif @approval.approved? && current_user&.admin?
+      if @approval.save
+        flash.now.notice = '承認しました'
+      else
+        flash.now[:error] = '承認できませんでした'
+        render :new, status: :unprocessable_entity
+      end
+    elsif @approval.rejected? && current_user&.admin?
+      if @approval.save
+        flash.now.notice = '差戻しました'
+      else
+        flash.now[:error] = '差戻できませんでした'
+        render :new, status: :unprocessable_entity
+      end
     else
-      flash.now[:error] = message_error
+      flash.now[:error] = '権限がありません'
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -16,6 +16,9 @@ class ApprovalsController < ApplicationController
 
   def new
     @approval = @result.approvals.build
+
+    # submitボタンを前のレコードの値で出し分けるための判定用
+    @previous_approval = @result.approvals.order(created_at: :desc).first
   end
 
   def create

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -27,6 +27,7 @@ class ResultsController < ApplicationController
         } ]
       }
     }
+    @result_approvals = @result.approvals.order(created_at: :ASC)
   end
   def new
     @result = @sample.results.build

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -19,9 +19,18 @@ class Approval < ApplicationRecord
 
   validates :comment, length: { maximum: 100 }
 
+  validate :check_creatable
+
   enum action: {
     requested: 0,
     approved: 1,
     rejected: 2
   }
+
+  private
+    def check_creatable
+      if result.approved?
+        errors.add(:base, '承認済みです')
+      end
+    end
 end

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -22,28 +22,30 @@ class Approval < ApplicationRecord
   validate :check_creatable
   validate :check_previous_action
 
-  enum action: {
+  enum :action, {
     requested: 0,
     approved: 1,
     rejected: 2
-  }
+  }, validate: true
 
   private
-    def check_creatable
-      if result.approved?
-        errors.add(:base, '承認済みです')
-      end
+  # 承認済みのresultには新たにapprovalは作成できないように
+  def check_creatable
+    if result.approved?
+      errors.add(:base, '承認済みです')
     end
+  end
 
-    def check_previous_action
-      previous_approval = result.approvals.where.not(id: self.id).order(created_at: :desc).first
+  # 現在のactionの状態によって、次のactionを制限
+  def check_previous_action
+    previous_approval = result.approvals.where.not(id: self.id).order(created_at: :desc).first
 
-      if previous_approval.nil? && !self.requested?
-        errors.add(:base, '承認依頼してください')
-      elsif previous_approval&.requested? && self.requested?
-        errors.add(:base, 'すでに承認依頼中です')
-      elsif previous_approval&.rejected? && self.rejected?
-        errors.add(:base, 'すでに差戻中です')
-      end
+    if previous_approval.nil? && !self.requested?
+      errors.add(:base, '承認依頼してください')
+    elsif previous_approval&.requested? && self.requested?
+      errors.add(:base, 'すでに承認依頼中です')
+    elsif previous_approval&.rejected? && self.rejected?
+      errors.add(:base, 'すでに差戻中です')
     end
+  end
 end

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -20,6 +20,7 @@ class Approval < ApplicationRecord
   validates :comment, length: { maximum: 100 }
 
   validate :check_creatable
+  validate :check_previous_action
 
   enum action: {
     requested: 0,
@@ -31,6 +32,18 @@ class Approval < ApplicationRecord
     def check_creatable
       if result.approved?
         errors.add(:base, '承認済みです')
+      end
+    end
+
+    def check_previous_action
+      previous_approval = result.approvals.where.not(id: self.id).order(created_at: :desc).first
+
+      if previous_approval.nil? && !self.requested?
+        errors.add(:base, '承認依頼してください')
+      elsif previous_approval&.requested? && self.requested?
+        errors.add(:base, 'すでに承認依頼中です')
+      elsif previous_approval&.rejected? && self.rejected?
+        errors.add(:base, 'すでに差戻中です')
       end
     end
 end

--- a/app/views/approvals/_form.html.haml
+++ b/app/views/approvals/_form.html.haml
@@ -12,10 +12,10 @@
       = f.label :comment, "コメント"
       = f.text_area :comment
   .form-actions
-    - if @result.approvals.count == 0 || @result.approvals.last(2).first.action == 'rejected'
+    - if @previous_approval.nil? || @previous_approval&.rejected?
       = f.button "承認依頼", class: "btn btn-new", name: 'submit_type', value: 'requested'
-    - elsif @result.approvals.last(2).first.action == 'requested'
+    - elsif @previous_approval&.requested?
       = f.button "承認する", class: "btn btn-new", name: 'submit_type', value: 'approved'
       = f.button "差戻し", class: "btn btn-show", name: 'submit_type', value: 'rejected'
-    - else
-      approved
+    - elsif @previous_approval&.approved?
+      %p 承認済みです

--- a/app/views/results/_status.html.haml
+++ b/app/views/results/_status.html.haml
@@ -1,12 +1,11 @@
-
-- if !result.approvals.last
+- if !result.approvals.present?
   = link_to "未承認", new_plant_sample_result_approval_path(result.sample.plant, result.sample, result), class: "result_status", data: { turbo_frame: 'modal'}
-- elsif result.approvals.last.action == 'requested'
+- elsif result.latest_approval&.requested?
   -if current_user.admin == true
     = link_to "承認待ち", new_plant_sample_result_approval_path(result.sample.plant, result.sample, result), class: "result_status requested-admin", data: { turbo_frame: 'modal'}
   - else
     .result_status.requested 承認待ち
-- elsif result.approvals.last.action == 'approved'
+- elsif result.latest_approval&.approved?
   .result_status.approved 承認済
-- elsif result.approvals.last.action == 'rejected'
+- elsif result.latest_approval&.rejected?
   = link_to "差戻中", new_plant_sample_result_approval_path(result.sample.plant, result.sample, result), class: "result_status rejected", data: { turbo_frame: 'modal'}

--- a/app/views/results/show.html.haml
+++ b/app/views/results/show.html.haml
@@ -31,7 +31,7 @@
   %h2.result_approval-title 承認履歴
   = turbo_frame_tag 'approvals-list' do
     .result_approvals#approvals
-      - @result.approvals.each do |approval|
+      - @result_approvals.each do |approval|
         = render 'approval', approval: approval
       - unless @result.approvals.any?
         %p#no_approval_text 承認履歴はまだありません


### PR DESCRIPTION
- 承認済みの結果について、Approvalモデルで新規作成できないようにした
- 承認済みのとき、ApprovalsControllerでnew、createを無効にした
- 直前のapproval.actionによってバリデーションを設定
　（nil→requested、requested→approved or rejected、rejected→requested）
- 最新のapproval.actionによってviewの出し分けを設定
- approval.actionにrequested、approved、rejectedの3つの値以外を受け付けないようにバリデーションを設定
- 管理者のみが承認と差戻ができるように、ApprovalsControllerを修正